### PR TITLE
Remove unnecessary port mapping from docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,8 +3,6 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-    ports:
-      - "3000:3000"
     environment:
       - DATABASE_URL= ${DATABASE_URL}
     depends_on:


### PR DESCRIPTION
This pull request makes a minor adjustment to the `docker-compose.yml` configuration for the service. The change removes the explicit port mapping for port 3000.