### PR TITLE
Dev

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,9 +23,11 @@ services:
       - safecity-network
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U ${DB_USER} -d ${DB_NAME}"]
-      interval: 10s
+      interval: 30s
       timeout: 5s
       retries: 5
+    ports:
+      - "5431:5432"  # Expose PostgreSQL port
 
 networks:
   safecity-network:

--- a/src/config/mikro-orm.config.ts
+++ b/src/config/mikro-orm.config.ts
@@ -17,7 +17,7 @@ const databaseConfig: Options = {
   driver: PostgreSqlDriver,
   clientUrl:
     process.env.DATABASE_URL ||
-    'postgres://postgres:pgadmin@localhost:5432/safecity',
+    'postgres://postgres:postgres@localhost:5432/safecity',
 
   entities: [
     UserEntity,


### PR DESCRIPTION
This pull request introduces two small but important configuration changes to improve local development and database connectivity.

* Updated the default PostgreSQL connection string in `src/config/mikro-orm.config.ts` to use the password `postgres` instead of `pgadmin`, ensuring consistency with local database credentials.
* Exposed PostgreSQL port `5432` on host port `5431` and increased the healthcheck interval to 30 seconds in the `docker-compose.yml` file, making the database more accessible for local development and reducing healthcheck frequency.